### PR TITLE
Gracefully degrade in browsers which do not support `clipboard.write`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -616,12 +616,12 @@ function App() {
           });
       });
     } else {
-      navigator.clipboard
+      (navigator.clipboard.write ? navigator.clipboard
         .write([
           new ClipboardItem({
             [textBlob.type]: textBlob,
           }),
-        ])
+        ]) : navigator.clipboard.writeText(shareText))
         .then(() => {
           toast.success("Copied to clipboard!");
         })


### PR DESCRIPTION
I noticed sharing (image and text) was broken in Firefox (and IE I believe, though I haven't tested it). This is because the `clipboard.write` function doesn't exist. Here I've added a fallback to the older `clipboard.writeText` API.

Sharing images still won't work in these browsers, but at least text will now. If you think it's worth doing I could hide the `Copy (image)` button when it's not going to work.